### PR TITLE
feat(message): Implement retract message funtionality

### DIFF
--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -5,6 +5,30 @@ class MessageController {
     const response = MessageService.createMessage(req.body, req.body.email);
     return res.status(response.status).send(response);
   }
+
+  static retractMessage(req, res) {
+    const retractedMessage = MessageService.retractMessage(req.params.id);
+
+    if (retractedMessage) {
+      return res.status(200).json({
+        status: 200,
+        data: [
+          {
+            message: 'Message deleted/retracted succesfully'
+          }
+        ]
+      });
+    }
+
+    return res.status(404).json({
+      status: 404,
+      data: [
+        {
+          message: 'Message does not exist'
+        }
+      ]
+    });
+  }
 }
 
 export default MessageController;

--- a/server/routes/message.route.js
+++ b/server/routes/message.route.js
@@ -6,11 +6,13 @@ import MessageController from '../controllers/message.controller';
 
 const { getUser } = Auth;
 
-const { createMessage } = MessageController;
+const { createMessage, retractMessage } = MessageController;
 
 const { loginCheck, messageCheck } = Validate;
 
 const messageRouter = Router();
+
 messageRouter.post('/', getUser, loginCheck, messageCheck, createMessage);
+messageRouter.delete('/:id', retractMessage);
 
 export default messageRouter;

--- a/server/services/message.service.js
+++ b/server/services/message.service.js
@@ -100,6 +100,14 @@ class MessageService {
       };
     }
   }
+
+  static retractMessage(id) {
+    const messageIndex = mockData.messages.findIndex(message => message.id === parseInt(id, 10));
+    if (messageIndex !== -1) {
+      return mockData.messages.splice(messageIndex, 1);
+    }
+    return false;
+  }
 }
 
 export default MessageService;


### PR DESCRIPTION
#### What does this PR do?
- Implement the DELETE  ```api/v1/messages/<message-id>``` endpoint


#### Description of Task to be completed?
- implement retract message service

- implement retract message controller

- mount retract message route 

#### How should this be manually tested?
- Clone the repository using ```git clone https://github.com/fxola/EPIC-mail.git .``` in your terminal
- run ```npm install``` on your terminal
- run ```npm run start``` to start up the server
- start up postman and hit the route  DELETE ```api/v1/messages/<message-id>```


#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?
- PT Story link - [#164516556] (https://www.pivotaltracker.com/n/projects/2314937/stories/164516556)

#### Screenshots (if appropriate)
- N/A

#### Questions:
- N/A
